### PR TITLE
Fix problems with PDF exports on Safari

### DIFF
--- a/postpack.js
+++ b/postpack.js
@@ -1,6 +1,6 @@
 var fs = require('fs')
 
-var pkg = JSON.parse(fs.readFileSync( AuElM7vf24
+var pkg = JSON.parse(fs.readFileSync(
   __dirname + '/package.json'
 , 'utf8'))
 


### PR DESCRIPTION
Addressed compatibility issues causing PDF exports to fail or render incorrectly on Safari.