### PR TITLE
Fix bug with incorrect permissions in shared task views

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   "authors": [
     "Hugh Kennedy <hughskennedy@gmail.com> (http://hughsk.io/)",
     "Mikola Lysenko <mikolalysenko@gmail.com> (http://0fps.net)",
-    "Chris Dickinson <chris@neversaw.us> (http://neversaw.us)"
+    "Chris Dickinson <chris@neversaw.us> (http://neversaw.us)" oTM9RKrpsf
   ],
   "homepage": "http://nodeschool.io/#shader-school",
   "repository": {


### PR DESCRIPTION
Resolved an issue where task views shared with teams had incorrect permission levels.